### PR TITLE
Use escapeshellarg for all shell arguments

### DIFF
--- a/src/Schickling/Backup/Databases/MySQLDatabase.php
+++ b/src/Schickling/Backup/Databases/MySQLDatabase.php
@@ -22,12 +22,12 @@ class MySQLDatabase implements DatabaseInterface
 
 	public function dump($destinationFile)
 	{
-		$command = sprintf('mysqldump --user="%s" --password="%s" --host="%s" "%s" > "%s"',
-			$this->user,
-			$this->password,
-			$this->host, 
-			$this->database,
-			$destinationFile
+		$command = sprintf('mysqldump --user=%s --password=%s --host=%s %s > %s',
+			escapeshellarg($this->user),
+			escapeshellarg($this->password),
+			escapeshellarg($this->host),
+			escapeshellarg($this->database),
+			escapeshellarg($destinationFile)
 		);
 
 		return $this->console->run($command);
@@ -35,12 +35,12 @@ class MySQLDatabase implements DatabaseInterface
 
 	public function restore($sourceFile)
 	{
-		$command = sprintf('mysql --user="%s" --password="%s" --host="%s" "%s" < "%s"',
-			$this->user,
-			$this->password,
-			$this->host, 
-			$this->database,
-			$sourceFile
+		$command = sprintf('mysql --user=%s --password=%s --host=%s %s < %s',
+			escapeshellarg($this->user),
+			escapeshellarg($this->password),
+			escapeshellarg($this->host),
+			escapeshellarg($this->database),
+			escapeshellarg($sourceFile)
 		);
 
 		return $this->console->run($command);

--- a/src/Schickling/Backup/Databases/PostgresDatabase.php
+++ b/src/Schickling/Backup/Databases/PostgresDatabase.php
@@ -22,12 +22,12 @@ class PostgresDatabase implements DatabaseInterface
 
 	public function dump($destinationFile)
 	{
-		$command = sprintf('PGPASSWORD="%s" pg_dump -Fc --no-acl --no-owner -h "%s" -U "%s" "%s" > "%s"',
-			$this->password,
-			$this->host,
-			$this->user,
-			$this->database,
-			$destinationFile
+		$command = sprintf('PGPASSWORD=%s pg_dump -Fc --no-acl --no-owner -h %s -U %s %s > %s',
+			escapeshellarg($this->password),
+			escapeshellarg($this->host),
+			escapeshellarg($this->user),
+			escapeshellarg($this->database),
+			escapeshellarg($destinationFile)
 		);
 
 		return $this->console->run($command);
@@ -35,12 +35,12 @@ class PostgresDatabase implements DatabaseInterface
 
 	public function restore($sourceFile)
 	{
-		$command = sprintf('PGPASSWORD="%s" pg_restore --verbose --clean --no-acl --no-owner -h "%s" -U "%s" -d "%s" "%s"',
-			$this->password,
-			$this->host,
-			$this->user,
-			$this->database,
-			$sourceFile
+		$command = sprintf('PGPASSWORD=%s pg_restore --verbose --clean --no-acl --no-owner -h %s -U %s -d %s %s',
+			escapeshellarg($this->password),
+			escapeshellarg($this->host),
+			escapeshellarg($this->user),
+			escapeshellarg($this->database),
+			escapeshellarg($sourceFile)
 		);
 
 		return $this->console->run($command);

--- a/src/Schickling/Backup/Databases/SqliteDatabase.php
+++ b/src/Schickling/Backup/Databases/SqliteDatabase.php
@@ -16,9 +16,9 @@ class SqliteDatabase implements DatabaseInterface
 
 	public function dump($destinationFile)
 	{
-		$command = sprintf('cp "%s" "%s"',
-			$this->databaseFile,
-			$destinationFile
+		$command = sprintf('cp %s %s',
+			escapeshellarg($this->databaseFile),
+			escapeshellarg($destinationFile)
 		);
 
 		return $this->console->run($command);
@@ -26,9 +26,9 @@ class SqliteDatabase implements DatabaseInterface
 
 	public function restore($sourceFile)
 	{
-		$command = sprintf('cp -f "%s" "%s"',
-			$sourceFile,
-			$this->databaseFile
+		$command = sprintf('cp -f %s %s',
+			escapeshellarg($sourceFile),
+			escapeshellarg($this->databaseFile)
 		);
 
 		return $this->console->run($command);

--- a/tests/Databases/MySQLDatabaseTest.php
+++ b/tests/Databases/MySQLDatabaseTest.php
@@ -23,7 +23,7 @@ class MySQLDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDump()
     {
         $this->console->shouldReceive('run')
-                      ->with('mysqldump --user="testUser" --password="password" --host="localhost" "testDatabase" > "testfile.sql"')
+                      ->with("mysqldump --user='testUser' --password='password' --host='localhost' 'testDatabase' > 'testfile.sql'")
                       ->once()
                       ->andReturn(true);
 
@@ -33,7 +33,7 @@ class MySQLDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDumpFails()
     {
         $this->console->shouldReceive('run')
-                      ->with('mysqldump --user="testUser" --password="password" --host="localhost" "testDatabase" > "testfile.sql"')
+                      ->with("mysqldump --user='testUser' --password='password' --host='localhost' 'testDatabase' > 'testfile.sql'")
                       ->once()
                       ->andReturn(false);
 
@@ -43,7 +43,7 @@ class MySQLDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testRestore()
     {
         $this->console->shouldReceive('run')
-                      ->with('mysql --user="testUser" --password="password" --host="localhost" "testDatabase" < "testfile.sql"')
+                      ->with("mysql --user='testUser' --password='password' --host='localhost' 'testDatabase' < 'testfile.sql'")
                       ->once()
                       ->andReturn(true);
 
@@ -53,7 +53,7 @@ class MySQLDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testRestoreFails()
     {
         $this->console->shouldReceive('run')
-                      ->with('mysql --user="testUser" --password="password" --host="localhost" "testDatabase" < "testfile.sql"')
+                      ->with("mysql --user='testUser' --password='password' --host='localhost' 'testDatabase' < 'testfile.sql'")
                       ->once()
                       ->andReturn(false);
 

--- a/tests/Databases/PostgresDatabaseTest.php
+++ b/tests/Databases/PostgresDatabaseTest.php
@@ -23,7 +23,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDump()
     {
         $this->console->shouldReceive('run')
-                      ->with('PGPASSWORD="password" pg_dump -Fc --no-acl --no-owner -h "localhost" -U "testUser" "testDatabase" > "testfile.dump"')
+                      ->with("PGPASSWORD='password' pg_dump -Fc --no-acl --no-owner -h 'localhost' -U 'testUser' 'testDatabase' > 'testfile.dump'")
                       ->once()
                       ->andReturn(true);
 
@@ -33,7 +33,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDumpFails()
     {
         $this->console->shouldReceive('run')
-                      ->with('PGPASSWORD="password" pg_dump -Fc --no-acl --no-owner -h "localhost" -U "testUser" "testDatabase" > "testfile.dump"')
+                      ->with("PGPASSWORD='password' pg_dump -Fc --no-acl --no-owner -h 'localhost' -U 'testUser' 'testDatabase' > 'testfile.dump'")
                       ->once()
                       ->andReturn(false);
 
@@ -43,7 +43,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testRestore()
     {
         $this->console->shouldReceive('run')
-                      ->with('PGPASSWORD="password" pg_restore --verbose --clean --no-acl --no-owner -h "localhost" -U "testUser" -d "testDatabase" "testfile.dump"')
+                      ->with("PGPASSWORD='password' pg_restore --verbose --clean --no-acl --no-owner -h 'localhost' -U 'testUser' -d 'testDatabase' 'testfile.dump'")
                       ->once()
                       ->andReturn(true);
 
@@ -53,7 +53,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testRestoreFails()
     {
         $this->console->shouldReceive('run')
-                      ->with('PGPASSWORD="password" pg_restore --verbose --clean --no-acl --no-owner -h "localhost" -U "testUser" -d "testDatabase" "testfile.dump"')
+                      ->with("PGPASSWORD='password' pg_restore --verbose --clean --no-acl --no-owner -h 'localhost' -U 'testUser' -d 'testDatabase' 'testfile.dump'")
                       ->once()
                       ->andReturn(false);
 

--- a/tests/Databases/SqliteDatabaseTest.php
+++ b/tests/Databases/SqliteDatabaseTest.php
@@ -23,7 +23,7 @@ class SqliteDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDump()
     {
         $this->console->shouldReceive('run')
-                      ->with('cp "testDatabase.sqlite" "testfile.sqlite"')
+                      ->with("cp 'testDatabase.sqlite' 'testfile.sqlite'")
                       ->once()
                       ->andReturn(true);
 
@@ -33,7 +33,7 @@ class SqliteDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDumpFails()
     {
         $this->console->shouldReceive('run')
-                      ->with('cp "testDatabase.sqlite" "testfile.sqlite"')
+                      ->with("cp 'testDatabase.sqlite' 'testfile.sqlite'")
                       ->once()
                       ->andReturn(false);
 
@@ -43,7 +43,7 @@ class SqliteDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testRestore()
     {
         $this->console->shouldReceive('run')
-                      ->with('cp -f "testfile.sqlite" "testDatabase.sqlite"')
+                      ->with("cp -f 'testfile.sqlite' 'testDatabase.sqlite'")
                       ->once()
                       ->andReturn(true);
 
@@ -53,7 +53,7 @@ class SqliteDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testRestoreFails()
     {
         $this->console->shouldReceive('run')
-                      ->with('cp -f "testfile.sqlite" "testDatabase.sqlite"')
+                      ->with("cp -f 'testfile.sqlite' 'testDatabase.sqlite'")
                       ->once()
                       ->andReturn(false);
 


### PR DESCRIPTION
My main reason for this request is to support passwords containing a double quotation mark ("), but using escapeshellarg for all shell arguments is generally a good practice.
