### PR TITLE
Support filename argument for db:backup

### DIFF
--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -24,17 +24,11 @@ class BackupCommand extends BaseCommand
 				$this->filePath = $this->argument('filename');
 				$this->fileName = basename($this->filePath);
 			}
-			// Is it relative path?
-			else if (strpos($this->argument('filename'), '/') !== false) 
+			// It's relative path?
+			else
 			{
 				$this->filePath = getcwd() . '/' . $this->argument('filename');
 				$this->fileName = basename($this->filePath);
-			}
-			// It's a basename:
-			else
-			{
-				$this->fileName = $this->argument('filename');
-				$this->filePath = rtrim($this->getDumpsPath(), '/') . '/' . $this->fileName;
 			}
 		}
 		else

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -15,9 +15,6 @@ class BackupCommandTest extends TestCase
         parent::setUp();
 
         $this->databaseMock = m::mock('Schickling\Backup\Databases\DatabaseInterface');
-        $this->databaseMock->shouldReceive('getFileExtension')
-                           ->once()
-                           ->andReturn('sql');
 
         $command = new BackupCommand($this->databaseMock);
 
@@ -46,6 +43,11 @@ class BackupCommandTest extends TestCase
 
     public function testSuccessfulBackup()
     {
+
+        $this->databaseMock->shouldReceive('getFileExtension')
+                           ->once()
+                           ->andReturn('sql');
+
         $this->databaseMock->shouldReceive('dump')
                            ->once()
                            ->andReturn(true);
@@ -57,6 +59,11 @@ class BackupCommandTest extends TestCase
 
     public function testFailingBackup()
     {
+
+        $this->databaseMock->shouldReceive('getFileExtension')
+                           ->once()
+                           ->andReturn('sql');
+
         $this->databaseMock->shouldReceive('dump')
                            ->once()
                            ->andReturn('Error message');
@@ -77,6 +84,10 @@ class BackupCommandTest extends TestCase
            ->with('s3')
            ->andReturn($s3Mock);
 
+        $this->databaseMock->shouldReceive('getFileExtension')
+                           ->once()
+                           ->andReturn('sql');
+
         $this->databaseMock->shouldReceive('dump')
                            ->once()
                            ->andReturn(true);
@@ -90,4 +101,43 @@ class BackupCommandTest extends TestCase
         $this->assertEquals("Upload complete.", $lines[1]);
 
     }
+
+    public function testAbsolutePathAsFilename()
+    {
+
+        $this->databaseMock->shouldReceive('getFileExtension')
+                           ->never();
+
+        $this->databaseMock->shouldReceive('dump')
+                           ->once()
+                           ->andReturn(true);
+
+        $filename = '/home/dummy/mydump.sql';
+
+        $this->tester->execute(array(
+            'filename' => $filename
+            ));
+
+        $this->assertEquals('Database backup was successful. Saved to ' . $filename . "\n", $this->tester->getDisplay());
+    }
+
+    public function testRelativePathAsFilename()
+    {
+
+        $this->databaseMock->shouldReceive('getFileExtension')
+                           ->never();
+
+        $this->databaseMock->shouldReceive('dump')
+                           ->once()
+                           ->andReturn(true);
+
+        $filename = 'dummy/mydump.sql';
+
+        $this->tester->execute(array(
+            'filename' => $filename
+            ));
+
+        $this->assertEquals('Database backup was successful. Saved to ' . getcwd() . '/' . $filename . "\n", $this->tester->getDisplay());
+    }
+
 }


### PR DESCRIPTION
I needed to store backups to a custom path, so I made a quick implementation of filename support. Not very elegant, but it works. I'm not sure what you think about supporting absolute paths. If you are not opposed to the idea, it might be an idea to add support for it to db:restore also for consistency.
