### PR TITLE
Add command line option to specify database

### DIFF
--- a/src/Schickling/Backup/BackupServiceProvider.php
+++ b/src/Schickling/Backup/BackupServiceProvider.php
@@ -11,17 +11,17 @@ class BackupServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$databaseBuilder = new DatabaseBuilder($this->app->config['database']);
-		$database = $databaseBuilder->getDatabase();
 
-		$this->app['db.backup'] = $this->app->share(function($app) use ($database)
+		$databaseBuilder = new DatabaseBuilder();
+
+		$this->app['db.backup'] = $this->app->share(function($app) use ($databaseBuilder)
 		{
-			return new Commands\BackupCommand($database);
+			return new Commands\BackupCommand($databaseBuilder);
 		});
 
-		$this->app['db.restore'] = $this->app->share(function($app) use ($database)
+		$this->app['db.restore'] = $this->app->share(function($app) use ($databaseBuilder)
 		{
-			return new Commands\RestoreCommand($database);
+			return new Commands\RestoreCommand($databaseBuilder);
 		});
 
 		$this->commands(

--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -14,6 +14,7 @@ class BackupCommand extends BaseCommand
 
 	public function fire()
 	{
+		$database = $this->getDatabase($this->input->getOption('database'));
 		$this->checkDumpFolder();
 
 		if ($this->argument('filename'))
@@ -24,20 +25,26 @@ class BackupCommand extends BaseCommand
 				$this->filePath = $this->argument('filename');
 				$this->fileName = basename($this->filePath);
 			}
-			// It's relative path?
-			else
+			// Is it relative path?
+			else if (strpos($this->argument('filename'), '/') !== false) 
 			{
 				$this->filePath = getcwd() . '/' . $this->argument('filename');
 				$this->fileName = basename($this->filePath);
 			}
+			// It's a basename:
+			else
+			{
+				$this->fileName = $this->argument('filename');
+				$this->filePath = rtrim($this->getDumpsPath(), '/') . '/' . $this->fileName;
+			}
 		}
 		else
 		{
-			$this->fileName = date('YmdHis') . '.' .$this->database->getFileExtension();
+			$this->fileName = date('YmdHis') . '.' .$database->getFileExtension();
 			$this->filePath = rtrim($this->getDumpsPath(), '/') . '/' . $this->fileName;
 		}
 
-		$status = $this->database->dump($this->filePath);
+		$status = $database->dump($this->filePath);
 
 		if ($status === true)
 		{
@@ -77,6 +84,7 @@ class BackupCommand extends BaseCommand
 	protected function getOptions()
 	{
 		return array(
+			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to backup'),
 			array('upload-s3', 'u', InputOption::VALUE_REQUIRED, 'Upload the dump to your S3 bucket')
 			);
 	}

--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -25,17 +25,11 @@ class BackupCommand extends BaseCommand
 				$this->filePath = $this->argument('filename');
 				$this->fileName = basename($this->filePath);
 			}
-			// Is it relative path?
-			else if (strpos($this->argument('filename'), '/') !== false) 
+			// It's relative path?
+			else
 			{
 				$this->filePath = getcwd() . '/' . $this->argument('filename');
 				$this->fileName = basename($this->filePath);
-			}
-			// It's a basename:
-			else
-			{
-				$this->fileName = $this->argument('filename');
-				$this->filePath = rtrim($this->getDumpsPath(), '/') . '/' . $this->fileName;
 			}
 		}
 		else

--- a/src/Schickling/Backup/Commands/BaseCommand.php
+++ b/src/Schickling/Backup/Commands/BaseCommand.php
@@ -2,17 +2,23 @@
 
 use Illuminate\Console\Command;
 use Config;
-use Schickling\Backup\Databases\DatabaseInterface;
+use Schickling\Backup\DatabaseBuilder;
 
 class BaseCommand extends Command
 {
-	protected $database;
+	protected $databaseBuilder;
 
-	public function __construct(DatabaseInterface $database)
+	public function __construct(DatabaseBuilder $databaseBuilder)
 	{
 		parent::__construct();
+		$this->databaseBuilder = $databaseBuilder;
+	}
 
-		$this->database = $database;
+	public function getDatabase($database)
+	{
+		$database = $database ?: Config::get('database.default');
+		$realConfig = Config::get("database.connections.$database");
+		return $this->databaseBuilder->getDatabase($realConfig);
 	}
 
 	protected function getDumpsPath()

--- a/src/Schickling/Backup/Commands/RestoreCommand.php
+++ b/src/Schickling/Backup/Commands/RestoreCommand.php
@@ -32,7 +32,9 @@ class RestoreCommand extends BaseCommand
 	{
 		$sourceFile = $this->getDumpsPath() . $fileName;
 
-		if ($this->database->restore($sourceFile))
+		$status = $this->database->restore($sourceFile);
+		
+		if ($status === true)
 		{
 			$this->line(sprintf($this->colors->getColoredString("\n".'%s was successfully restored.'."\n",'green'), $fileName));
 		}
@@ -81,7 +83,7 @@ class RestoreCommand extends BaseCommand
 	{
 		return array(
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to restore to'),
-			);
+		);
 	}
 
 }

--- a/src/Schickling/Backup/Commands/RestoreCommand.php
+++ b/src/Schickling/Backup/Commands/RestoreCommand.php
@@ -1,5 +1,6 @@
 <?php namespace Schickling\Backup\Commands;
 
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Finder\Finder;
 
@@ -9,8 +10,12 @@ class RestoreCommand extends BaseCommand
 
 	protected $description = 'Restore a dump from `app/storage/dumps`';
 
+	protected $database;
+
 	public function fire()
 	{		
+		$this->database = $this->getDatabase($this->input->getOption('database'));
+
 		$fileName = $this->argument('dump');
 		
 		if ($fileName)
@@ -26,6 +31,7 @@ class RestoreCommand extends BaseCommand
 	protected function restoreDump($fileName)
 	{
 		$sourceFile = $this->getDumpsPath() . $fileName;
+
 
 		if ($this->database->restore($sourceFile))
 		{
@@ -63,6 +69,13 @@ class RestoreCommand extends BaseCommand
 	{
 		return array(
 			array('dump', InputArgument::OPTIONAL, 'Filename of the dump')
+			);
+	}
+
+	protected function getOptions()
+	{
+		return array(
+			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to restore to'),
 			);
 	}
 

--- a/src/Schickling/Backup/DatabaseBuilder.php
+++ b/src/Schickling/Backup/DatabaseBuilder.php
@@ -5,12 +5,13 @@ class DatabaseBuilder
 	protected $database;
 	protected $console;
 
-	public function __construct(array $config)
+	public function __construct()
 	{
 		$this->console = new Console();
+	}
 
-		$default = $config['default'];
-		$realConfig = $config['connections'][$default];
+	public function getDatabase(array $realConfig)
+	{
 
 		switch ($realConfig['driver'])
 		{
@@ -30,10 +31,7 @@ class DatabaseBuilder
 			throw new \Exception('Database driver not supported yet');
 			break;
 		}
-	}
 
-	public function getDatabase()
-	{
 		return $this->database;
 	}
 

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -15,8 +15,12 @@ class BackupCommandTest extends TestCase
         parent::setUp();
 
         $this->databaseMock = m::mock('Schickling\Backup\Databases\DatabaseInterface');
+        $this->databaseBuilderMock = m::mock('Schickling\Backup\DatabaseBuilder');
+        $this->databaseBuilderMock->shouldReceive('getDatabase')
+                           ->once()
+                           ->andReturn($this->databaseMock);
 
-        $command = new BackupCommand($this->databaseMock);
+        $command = new BackupCommand($this->databaseBuilderMock);
 
         $this->tester = new CommandTester($command);
     }

--- a/tests/Commands/RestoreCommandTest.php
+++ b/tests/Commands/RestoreCommandTest.php
@@ -15,8 +15,12 @@ class RestoreCommandTest extends TestCase
         parent::setUp();
 
         $this->databaseMock = m::mock('Schickling\Backup\Databases\DatabaseInterface');
+        $this->databaseBuilderMock = m::mock('Schickling\Backup\DatabaseBuilder');
+        $this->databaseBuilderMock->shouldReceive('getDatabase')
+                           ->once()
+                           ->andReturn($this->databaseMock);
 
-        $command = new RestoreCommand($this->databaseMock);
+        $command = new RestoreCommand($this->databaseBuilderMock);
 
         $this->tester = new CommandTester($command);
     }

--- a/tests/DatabaseBuilderTest.php
+++ b/tests/DatabaseBuilderTest.php
@@ -5,78 +5,60 @@ use Schickling\Backup\DatabaseBuilder;
 class DatabaseBuilderTest extends \PHPUnit_Framework_TestCase
 {
 
-    protected $databaseBuilder;
-
     public function testMySQL()
     {
         $config = array(
-            'default'       => 'mysqlTest',
-            'connections'   => array(
-                'mysqlTest' => array(
                     'driver'    => 'mysql',
                     'host'      => 'localhost',
                     'database'  => 'database',
                     'username'  => 'root',
                     'password'  => '',
-                    )
-                )
-            );
+                    );
 
-        $this->databaseBuilder = new DatabaseBuilder($config);
+        $databaseBuilder = new DatabaseBuilder();
+        $database = $databaseBuilder->getDatabase($config);
 
-        $this->assertInstanceOf('Schickling\Backup\Databases\MySQLDatabase', $this->databaseBuilder->getDatabase());
+        $this->assertInstanceOf('Schickling\Backup\Databases\MySQLDatabase', $database);
     }
 
     public function testSqlite()
     {
         $config = array(
-            'default'       => 'sqliteTest',
-            'connections'   => array(
-                'sqliteTest' => array(
                     'driver'   => 'sqlite',
                     'database' => __DIR__.'/../database/production.sqlite',
-                    )
-                )
-            );
+                    );
 
-        $this->databaseBuilder = new DatabaseBuilder($config);
+        $databaseBuilder = new DatabaseBuilder();
+        $database = $databaseBuilder->getDatabase($config);
 
-        $this->assertInstanceOf('Schickling\Backup\Databases\SqliteDatabase', $this->databaseBuilder->getDatabase());
+        $this->assertInstanceOf('Schickling\Backup\Databases\SqliteDatabase', $database);
     }
 
     public function testPostgres() {
         $config = array(
-            'default'       => 'postgresTest',
-            'connections'   => array(
-                'postgresTest' => array(
                     'driver'    => 'pgsql',
                     'host'      => 'localhost',
                     'database'  => 'database',
                     'username'  => 'root',
                     'password'  => 'paso',
-                    )
-                )
-            );
+                    );
 
-        $this->databaseBuilder = new DatabaseBuilder($config);
+        $databaseBuilder = new DatabaseBuilder();
+        $database = $databaseBuilder->getDatabase($config);
 
-        $this->assertInstanceOf('Schickling\Backup\Databases\PostgresDatabase', $this->databaseBuilder->getDatabase());
+        $this->assertInstanceOf('Schickling\Backup\Databases\PostgresDatabase', $database);
     }
 
     public function testUnsupported()
     {
         $config = array(
-            'default'       => 'unsupportedTest',
-            'connections'   => array(
-                'unsupportedTest' => array(
                     'driver'   => 'unsupported',
-                    )
-                )
-            );
+                    );
 
         $this->setExpectedException('Exception');
 
-        $this->databaseBuilder = new DatabaseBuilder($config);
+        $databaseBuilder = new DatabaseBuilder();
+        $database = $databaseBuilder->getDatabase($config);
     }
 
 }


### PR DESCRIPTION
Let you specify a connection name from the config file of the current environment. E.g. `php artisan --database=mysql`

Since command line options are read in the command classes, which fires after the registration of the service provider, I moved the getDatabase part from the service provider to BaseCommand. This led to some restructuring..
