### PR TITLE
Added support for postgres --exclude-table-data option

### DIFF
--- a/src/Schickling/Backup/Databases/PostgresDatabase.php
+++ b/src/Schickling/Backup/Databases/PostgresDatabase.php
@@ -1,6 +1,7 @@
 <?php namespace Schickling\Backup\Databases;
 
 use Schickling\Backup\Console;
+use Config;
 
 class PostgresDatabase implements DatabaseInterface
 {
@@ -22,8 +23,12 @@ class PostgresDatabase implements DatabaseInterface
 
 	public function dump($destinationFile)
 	{
-		$command = sprintf('PGPASSWORD=%s pg_dump -Fc --no-acl --no-owner -h %s -U %s %s > %s',
+		$excludedTablesStr = implode(' ', array_map(function ($table) {
+			return '--exclude-table-data=' . escapeshellarg($table);
+		}, $this->getExcludedTables()));
+		$command = sprintf('PGPASSWORD=%s pg_dump -Fc --no-acl --no-owner %s -h %s -U %s %s > %s',
 			escapeshellarg($this->password),
+			$excludedTablesStr,
 			escapeshellarg($this->host),
 			escapeshellarg($this->user),
 			escapeshellarg($this->database),
@@ -49,5 +54,10 @@ class PostgresDatabase implements DatabaseInterface
 	public function getFileExtension()
 	{
 		return 'dump';
+	}
+
+	protected function getExcludedTables()
+	{
+		return Config::get('backup::postgres.exclude_table_data', []);
 	}
 }

--- a/src/Schickling/Backup/Databases/PostgresDatabase.php
+++ b/src/Schickling/Backup/Databases/PostgresDatabase.php
@@ -58,6 +58,6 @@ class PostgresDatabase implements DatabaseInterface
 
 	protected function getExcludedTables()
 	{
-		return Config::get('backup::postgres.exclude_table_data', []);
+		return Config::get('backup::postgres.exclude_table_data', array());
 	}
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -13,4 +13,12 @@ return array(
 		'path' => ''
 		),
 
-	);
+	'postgres' => array(
+		'exclude_table_data' => array(
+			//'cache',
+			//'failed_jobs',
+			//'sessions',
+			),
+		),
+
+);

--- a/tests/Databases/PostgresDatabaseTest.php
+++ b/tests/Databases/PostgresDatabaseTest.php
@@ -23,7 +23,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDump()
     {
         $this->console->shouldReceive('run')
-                      ->with("PGPASSWORD='password' pg_dump -Fc --no-acl --no-owner -h 'localhost' -U 'testUser' 'testDatabase' > 'testfile.dump'")
+                      ->with("PGPASSWORD='password' pg_dump -Fc --no-acl --no-owner  -h 'localhost' -U 'testUser' 'testDatabase' > 'testfile.dump'")
                       ->once()
                       ->andReturn(true);
 
@@ -33,7 +33,7 @@ class PostgresDatabaseTest extends \PHPUnit_Framework_TestCase
     public function testDumpFails()
     {
         $this->console->shouldReceive('run')
-                      ->with("PGPASSWORD='password' pg_dump -Fc --no-acl --no-owner -h 'localhost' -U 'testUser' 'testDatabase' > 'testfile.dump'")
+                      ->with("PGPASSWORD='password' pg_dump -Fc --no-acl --no-owner  -h 'localhost' -U 'testUser' 'testDatabase' > 'testfile.dump'")
                       ->once()
                       ->andReturn(false);
 


### PR DESCRIPTION
Added support for postgres `--exclude-table-data` option to skip data from certain tables during backup. 

Just declare list of tables in `postgres.exclude_table_data` config directive:

``` php
return [
    'path' => storage_path('dumps'),
    'postgres' => [
        'exclude_table_data' => [
            'api_requests_log',
            'autologin_tokens',
            'cache',
            'carwash_statistic_log',
            'carwashes_index',
            'failed_jobs',
            'password_reminders',
            'sessions',
        ],
    ],
];
```
