### PR TITLE
Added keep-only-s3 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ $ php artisan db:backup --database=mysql
 ```sh
 $ php artisan db:backup --upload-s3 your-bucket
 ```
+
+Note: if you are planning to upload only to S3 and don't want to keep a local copy of the SQL dump use the `--keep-s3-only` option.
+
 Uses the [aws/aws-sdk-php-laravel](https://github.com/aws/aws-sdk-php-laravel) package which needs to be [configured](https://github.com/aws/aws-sdk-php-laravel#configuration).
 
 #### Restore

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ php artisan db:backup --database=mysql
 $ php artisan db:backup --upload-s3 your-bucket
 ```
 
-Note: if you are planning to upload only to S3 and don't want to keep a local copy of the SQL dump use the `--keep-s3-only` option.
+You can use the `--keep-only-s3` option if you don't want to keep a local copy of the SQL dump.
 
 Uses the [aws/aws-sdk-php-laravel](https://github.com/aws/aws-sdk-php-laravel) package which needs to be [configured](https://github.com/aws/aws-sdk-php-laravel#configuration).
 

--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -55,6 +55,12 @@ class BackupCommand extends BaseCommand
 			{
 				$this->uploadS3();
 				$this->line($this->colors->getColoredString("\n".'Upload complete.'."\n",'green'));
+
+				if ($this->option('unlink-after-s3'))
+				{
+					unlink($this->filePath);
+					$this->line($this->colors->getColoredString("\n".'Removed dump as it\'s now stored on S3.'."\n",'green'));
+				}
 			}
 		}
 		else
@@ -79,8 +85,9 @@ class BackupCommand extends BaseCommand
 	{
 		return array(
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to backup'),
-			array('upload-s3', 'u', InputOption::VALUE_REQUIRED, 'Upload the dump to your S3 bucket')
-			);
+			array('upload-s3', 'u', InputOption::VALUE_REQUIRED, 'Upload the dump to your S3 bucket'),
+			array('unlink-after-s3', true, InputOption::VALUE_NONE, 'The database connection to backup')
+		);
 	}
 
 	protected function checkDumpFolder()

--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -4,6 +4,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use AWS;
 use Config;
+use File;
 
 class BackupCommand extends BaseCommand
 {

--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -56,9 +56,9 @@ class BackupCommand extends BaseCommand
 				$this->uploadS3();
 				$this->line($this->colors->getColoredString("\n".'Upload complete.'."\n",'green'));
 
-				if ($this->option('unlink-after-s3'))
+				if ($this->option('keep-only-s3'))
 				{
-					unlink($this->filePath);
+					File::delete($this->filePath);
 					$this->line($this->colors->getColoredString("\n".'Removed dump as it\'s now stored on S3.'."\n",'green'));
 				}
 			}
@@ -86,7 +86,7 @@ class BackupCommand extends BaseCommand
 		return array(
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to backup'),
 			array('upload-s3', 'u', InputOption::VALUE_REQUIRED, 'Upload the dump to your S3 bucket'),
-			array('unlink-after-s3', true, InputOption::VALUE_NONE, 'The database connection to backup')
+			array('keep-only-s3', true, InputOption::VALUE_NONE, 'Delete the local dump after upload to S3 bucket')
 		);
 	}
 

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -99,9 +99,34 @@ class BackupCommandTest extends TestCase
         $this->tester->execute(array(
             '--upload-s3' => 'bucket-title'
             ));
+    }
 
-        // $this->assertRegExp("/^(\\033\[[0-9;]*m)*(\\n)*Database backup was successful. [0-9]{14}.sql was saved in the dumps folder.(\\n)*(\\033\[0m)*(\\033\[[0-9;]*m)*(\\n)*Upload complete.(\\n)*(\\033\[0m)*$/", $this->tester->getDisplay());
+     public function testKeepOnlyS3()
+    {
+        $s3Mock = m::mock();
+        $s3Mock->shouldReceive('putObject')
+               ->andReturn(true);
 
+        AWS::shouldReceive('get')
+           ->once()
+           ->with('s3')
+           ->andReturn($s3Mock);
+
+        File::shouldReceive('delete')
+              ->once()
+              ->andReturn(true);
+
+        $this->databaseMock->shouldReceive('getFileExtension')
+                           ->once()
+                           ->andReturn('sql');
+
+        $this->databaseMock->shouldReceive('dump')
+                           ->once()
+                           ->andReturn(true);
+
+        $this->tester->execute(array(
+          '--keep-only-s3'
+        ));
     }
 
     public function testAbsolutePathAsFilename()

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -125,7 +125,8 @@ class BackupCommandTest extends TestCase
                            ->andReturn(true);
 
         $this->tester->execute(array(
-          '--keep-only-s3'
+          '--upload-s3' => 'bucket-title',
+          '--keep-only-s3' => true
         ));
     }
 


### PR DESCRIPTION
My backup folder was filling up - ended up being 8GB. Realised that s3 upload option isn't actually removing the dumps once it's been sent to s3. I've added the ability to use --unlink-after-s3 (happy for you to rename as you like). This will unlink the file if the option is set.
