### PR TITLE
Simpler install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@ Backup and restore database support for Laravel 4 applications
 
 ## Installation
 
-1. Add the following to your composer.json and run `composer update`
+1. Run the following command:
 
-    ```json
-    {
-        "require": {
-            "schickling/backup": "dev-master"
-        }
-    }
-    ```
+```bash
+$ composer require schickling/backup
+```
 
 2. Add `Schickling\Backup\BackupServiceProvider` to your config/app.php
 


### PR DESCRIPTION
This will make Composer automatically require the latest stable version (`~5.0.1`), people should never use `dev-master`.
