### PR TITLE
laravel 5 patch

### DIFF
--- a/src/Schickling/Backup/BackupServiceProvider.php
+++ b/src/Schickling/Backup/BackupServiceProvider.php
@@ -11,7 +11,9 @@ class BackupServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('schickling/backup');
+		$this->publishes([
+			__DIR__.'/../../config/config.php' => config_path('backup.php'),
+		]);
 	}
 
 	/**

--- a/src/Schickling/Backup/Commands/BackupCommand.php
+++ b/src/Schickling/Backup/Commands/BackupCommand.php
@@ -133,6 +133,6 @@ class BackupCommand extends BaseCommand
 	{
 		$default = 'dumps';
 
-		return Config::get('backup::s3.path', $default);;
+		return Config::get('backup.s3.path', $default);;
 	}
 }

--- a/src/Schickling/Backup/Commands/BaseCommand.php
+++ b/src/Schickling/Backup/Commands/BaseCommand.php
@@ -31,22 +31,22 @@ class BaseCommand extends Command
 
 	protected function getDumpsPath()
 	{
-		return Config::get('backup::path');
+		return Config::get('backup.path');
 	}
 
 	public function enableCompression()
 	{
-		return Config::set('backup::compress', true);
+		return Config::set('backup.compress', true);
 	}
 
 	public function disableCompression()
 	{
-		return Config::set('backup::compress', false);
+		return Config::set('backup.compress', false);
 	}
 
 	public function isCompressionEnabled()
 	{
-		return Config::get('backup::compress');
+		return Config::get('backup.compress');
 	}
 
 	public function isCompressed($fileName)

--- a/src/Schickling/Backup/Databases/MySQLDatabase.php
+++ b/src/Schickling/Backup/Databases/MySQLDatabase.php
@@ -59,11 +59,11 @@ class MySQLDatabase implements DatabaseInterface
 
 	protected function getDumpCommandPath()
 	{
-		return Config::get('backup::mysql.dump_command_path');;
+		return Config::get('backup.mysql.dump_command_path');;
 	}
 
 	protected function getRestoreCommandPath()
 	{
-		return Config::get('backup::mysql.restore_command_path');;
+		return Config::get('backup.mysql.restore_command_path');;
 	}
 }


### PR DESCRIPTION
a few minor changes to make the package compactible with Laravel 5
this worked for me to install it in laravel 5

``` json
"minimum-stability": "dev",
"repositories": [
        {
            "type": "git",
            "url": "https://github.com/Jir0/laravel-backup.git"
        }
    ],
    "require": {
        "laravel/framework": "dev-master as 4.1",
        "schickling/backup": "dev-master"
    },
```
